### PR TITLE
Remove eqhm_enabled property from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,6 @@
   "homepage": "https://github.com/pluginagentmarketplace/custom-plugin-android",
   "repository": "https://github.com/pluginagentmarketplace/custom-plugin-android",
   "license": "SEE LICENSE IN LICENSE",
-  "eqhm_enabled": true,
   "keywords": [
     "android",
     "kotlin",


### PR DESCRIPTION
Removed 'eqhm_enabled' property from plugin.json as it's not a valid field in the plugin.json schema and blocks installing in current Claude Code (v2.1.49)

Fixes #2