### PR TITLE
Fix plugin load failure: skill directory paths and invalid agent tools frontmatter

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -34,13 +34,13 @@
     "./agents/07-production.md"
   ],
   "skills": [
-    "./skills/fundamentals/SKILL.md",
-    "./skills/platform/SKILL.md",
-    "./skills/ui/SKILL.md",
-    "./skills/data/SKILL.md",
-    "./skills/networking/SKILL.md",
-    "./skills/architecture/SKILL.md",
-    "./skills/production/SKILL.md"
+    "./skills/fundamentals",
+    "./skills/platform",
+    "./skills/ui",
+    "./skills/data",
+    "./skills/networking",
+    "./skills/architecture",
+    "./skills/production"
   ],
   "commands": [
     "./commands/agent-guide.md",

--- a/agents/01-android-fundamentals.md
+++ b/agents/01-android-fundamentals.md
@@ -3,7 +3,6 @@ name: 01-android-fundamentals
 description: Kotlin & Java programming fundamentals, OOP, SOLID principles, functional programming, data structures, algorithms - complete programming foundation for Android development
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 

--- a/agents/02-platform.md
+++ b/agents/02-platform.md
@@ -3,7 +3,6 @@ name: 02-platform
 description: Android core components - Activities, Fragments, Services, Lifecycle, Intent system, Permissions (78 hours)
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 

--- a/agents/03-ui-development.md
+++ b/agents/03-ui-development.md
@@ -3,7 +3,6 @@ name: 03-ui-development
 description: UI Development - XML Layouts, Jetpack Compose, Material Design 3, responsive design, accessibility (235 hours)
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 

--- a/agents/04-data-management.md
+++ b/agents/04-data-management.md
@@ -3,7 +3,6 @@ name: 04-data-management
 description: Data Persistence & Storage - Room ORM, SQLite, DataStore, encryption, migrations (62 hours)
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 

--- a/agents/05-networking.md
+++ b/agents/05-networking.md
@@ -3,7 +3,6 @@ name: 05-networking
 description: API Integration & Networking - Retrofit, OkHttp, REST APIs, JSON, interceptors, SSL pinning (75 hours)
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 

--- a/agents/06-architecture.md
+++ b/agents/06-architecture.md
@@ -3,7 +3,6 @@ name: 06-architecture
 description: Architecture & Design Patterns - MVVM, Clean Architecture, Repository, SOLID, Hilt DI (40 hours)
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 

--- a/agents/07-production.md
+++ b/agents/07-production.md
@@ -3,7 +3,6 @@ name: 07-production
 description: Production Quality - Testing, Performance, Security, Deployment (95 hours)
 version: "2.0.0"
 model: sonnet
-tools: All tools
 sasmp_version: "1.3.0"
 eqhm_enabled: true
 


### PR DESCRIPTION
Fixes #4.

Two one-line-per-file fixes that make `android-development-assistant` 2.1.0 work out of the box when installed from the plugin marketplace:

### 1. `plugin.json`: skills declared as file paths instead of directories

Claude Code requires each `skills` entry to point at the skill's parent **directory**, not its `SKILL.md` file. As shipped, the plugin fails to load with 7 "failed to load" errors. Each entry now points at `./skills/<name>`.

### 2. `agents/*.md`: `tools: All tools` produces zero-tool agents

The frontmatter value `All tools` parses as a list of two unknown tool names, resolving to agents with **no tools at all** — every spawn is refused by the harness. Removing the `tools:` line lets agents inherit the full toolset, which appears to be the intent.

Both fixes were validated on a patched local install: all 7 agents load and run correctly (used extensively as implementation subagents on an Android TV project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)